### PR TITLE
adjust proof of PF2MF_comp_PF2MF for compat w/ Coq 8.7

### DIFF
--- a/mf/mf.v
+++ b/mf/mf.v
@@ -360,10 +360,10 @@ Lemma PF2MF_comp_PF2MF R S T (f: S -> option T) (g: R -> option S):
 	(PF2MF f \o PF2MF g) =~= PF2MF (f \o_p g).
 Proof.
 move => r t.
-split => [[[s [/=]]]].
-case E:  (g r) => // eq.
-case E': (f s) => // eq' _.
-by rewrite /pcomp /obind/oapp E eq E'.
+split.
+rewrite <- PF2MF_rcmp_PF2MF.
+intros [A _].
+exact A.
 rewrite /pcomp/obind/oapp/=.
 case E: (g r) => [s | ]//.
 case E': (f s) => // eq.


### PR DESCRIPTION
The original proof fails on "split" with the error 
```
File "./mf/mf.v", line 363, characters 0-21:
Error: only 1 intro pattern for 2 subgoals
```

The rest of rlzrs still is compatible with Coq-8.7 / mathcomp-1.6.4; didn't test earlier versions.